### PR TITLE
Fix simscity install from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "pandas",
         "scanpy",
         "scikit-learn",
-        "simscity",
+        "simscity @ git+https://github.com/czbiohub/simscity",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Currently installing from `setup.py` throws a confusing error about `simscity` not existing. This change allows users to install without worrying about what or where `simscity` is.