### PR TITLE
added expected log1p code

### DIFF
--- a/src/molecular_cross_validation/mcv_sweep.py
+++ b/src/molecular_cross_validation/mcv_sweep.py
@@ -16,7 +16,7 @@ import molecular_cross_validation.util as ut
 
 # copy of sklearn.model_selection._check_param_grid
 def _check_param_grid(param_grid):
-    if hasattr(param_grid, 'items'):
+    if hasattr(param_grid, "items"):
         param_grid = [param_grid]
 
     for p in param_grid:
@@ -24,15 +24,18 @@ def _check_param_grid(param_grid):
             if isinstance(v, np.ndarray) and v.ndim > 1:
                 raise ValueError("Parameter array should be one-dimensional.")
 
-            if (isinstance(v, str) or
-                    not isinstance(v, (np.ndarray, Sequence))):
-                raise ValueError("Parameter values for parameter ({0}) need "
-                                 "to be a sequence(but not a string) or"
-                                 " np.ndarray.".format(name))
+            if isinstance(v, str) or not isinstance(v, (np.ndarray, Sequence)):
+                raise ValueError(
+                    "Parameter values for parameter ({0}) need "
+                    "to be a sequence(but not a string) or"
+                    " np.ndarray.".format(name)
+                )
 
             if len(v) == 0:
-                raise ValueError("Parameter values for parameter ({0}) need "
-                                 "to be a non-empty sequence.".format(name))
+                raise ValueError(
+                    "Parameter values for parameter ({0}) need "
+                    "to be a non-empty sequence.".format(name)
+                )
 
 
 def poisson_nll_loss(y_pred: np.ndarray, y_true: np.ndarray) -> float:
@@ -72,6 +75,7 @@ class GridSearchMCV(BaseEstimator):
                          If None, the random number generator is the RandomState instance used
                          by `np.random`.
     """
+
     def __init__(
         self,
         denoiser: Callable,
@@ -81,7 +85,7 @@ class GridSearchMCV(BaseEstimator):
         n_splits: int = 1,
         loss: str = None,
         transformation: Union[str, Callable] = None,
-        random_state: Union[int, np.random.RandomState] = None
+        random_state: Union[int, np.random.RandomState] = None,
     ):
         self.denoiser = denoiser
         self.param_grid = param_grid
@@ -89,9 +93,11 @@ class GridSearchMCV(BaseEstimator):
 
         self.n_splits = n_splits
 
-        self.data_split, self.data_split_complement, self.overlap = (
-            ut.overlap_correction(data_split, sample_ratio)
-        )
+        (
+            self.data_split,
+            self.data_split_complement,
+            self.overlap,
+        ) = ut.overlap_correction(data_split, sample_ratio)
 
         if loss == "mse":
             self.loss = mean_squared_error
@@ -104,7 +110,7 @@ class GridSearchMCV(BaseEstimator):
 
         if transformation is None:
             self.transformation = lambda x: x
-        elif transformation == 'sqrt':
+        elif transformation == "sqrt":
             self.transformation = np.sqrt
         elif callable(transformation):
             self.transformation = transformation
@@ -118,7 +124,7 @@ class GridSearchMCV(BaseEstimator):
                 self.conversion = lambda x: (
                     x * self.data_split_complement / self.data_split
                 )
-            elif transformation == 'sqrt':
+            elif transformation == "sqrt":
                 self.conversion = lambda x: ut.convert_expectations(
                     x, self.data_split, self.data_split_complement
                 )

--- a/src/molecular_cross_validation/util.py
+++ b/src/molecular_cross_validation/util.py
@@ -10,14 +10,18 @@ import numba as nb
 
 
 # caching some values for efficiency
-taylor_range = np.arange(1, 128)
-sqrt_taylor_factors = scipy.special.factorial(taylor_range) / np.sqrt(taylor_range)
-log1p_taylor_factors = scipy.special.factorial(taylor_range) / np.log1p(taylor_range)
+coefficient_range = np.arange(1, 128)
+sqrt_expansion_coefficients = scipy.special.factorial(coefficient_range) / np.sqrt(
+    coefficient_range
+)
+log1p_expansion_coefficients = scipy.special.factorial(coefficient_range) / np.log1p(
+    coefficient_range
+)
 
 
 @nb.vectorize([nb.float64(nb.float64)], target="parallel")
 def sqrt_poisson_around_zero(x):
-    return np.exp(-x) * (x ** taylor_range / sqrt_taylor_factors).sum()
+    return np.exp(-x) * (x ** coefficient_range / sqrt_expansion_coefficients).sum()
 
 
 @nb.vectorize([nb.float64(nb.float64)], target="parallel")
@@ -27,7 +31,7 @@ def sqrt_poisson_around_mean(x):
 
 @nb.vectorize([nb.float64(nb.float64)], target="parallel")
 def log1p_poisson_around_zero(x):
-    return np.exp(-x) * (x ** taylor_range / log1p_taylor_factors).sum()
+    return np.exp(-x) * (x ** coefficient_range / log1p_expansion_coefficients).sum()
 
 
 @nb.vectorize([nb.float64(nb.float64, nb.float64)], target="parallel")


### PR DESCRIPTION
I felt like working on this so I pulled the code out of your branch and optimized it a little bit. It's using a truly silly number of factors for the expansion around zero, but both log1p and sqrt are accurate to within `0.00025`!

It should now be pretty simply to use `convert_exp_log1p` wherever we used `convert_exp_sqrt`, if we want.

I removed the `pseudocount` parameter from your code because the underlying functions assume that it's `1` (e.g. the pre-computed factors). If we want that parameter to be customizable (which seems reasonable, as most people don't use `1`) then we'll need to add some more code.