### PR TITLE
fix log1p_poisson_around_mean() numba signature

### DIFF
--- a/src/molecular_cross_validation/util.py
+++ b/src/molecular_cross_validation/util.py
@@ -34,7 +34,7 @@ def log1p_poisson_around_zero(x):
     return np.exp(-x) * (x ** coefficient_range / log1p_expansion_coefficients).sum()
 
 
-@nb.vectorize([nb.float64(nb.float64, nb.float64)], target="parallel")
+@nb.vectorize([nb.float64(nb.float64)], target="parallel")
 def log1p_poisson_around_mean(x):
     """
     Use Taylor expansion of log(1 + y) around y = x to evaluate


### PR DESCRIPTION
`import molecular_cross_validation.util` gives the following error:

TypeError: Failed in object mode pipeline (step: fix up args)
Signature mismatch: 2 argument types given, but function takes 1 arguments
